### PR TITLE
master libgit won't build with --static. Use v25

### DIFF
--- a/git-gb.go
+++ b/git-gb.go
@@ -12,7 +12,7 @@ import (
 	ioutil "io/ioutil"
 
 	"github.com/codegangsta/cli"
-	git "github.com/libgit2/git2go"
+	git "gopkg.in/libgit2/git2go.v25"
 	"github.com/mgutz/ansi"
 )
 


### PR DESCRIPTION
git2go doesn't support static builds from the master branch. https://github.com/libgit2/git2go/issues/339